### PR TITLE
timestamp 이름 변경

### DIFF
--- a/StreamerSensor0302/src/main/java/com/mapper/AdminMapper.java
+++ b/StreamerSensor0302/src/main/java/com/mapper/AdminMapper.java
@@ -17,9 +17,9 @@ public interface AdminMapper {
 			+ "where admin_id = #{admin_id}")
 	Admin getAdminInfo(int admin_id);
 	
-	@Select("select stat_id, total_revenue, visit_count, timestamp "
+	@Select("select stat_id, total_revenue, visit_count, site_stat_date "
 			+ "from site_stat "
-			+ "order by timestamp desc")
+			+ "order by site_stat_date desc")
 	List<SiteInfo> getSiteInfo();
 	
 	@Update("UPDATE site_stat set visit_count = #{visit_count} "


### PR DESCRIPTION
기존 AdminMapper에 있던 timestamp를 DB에서 site_stat_date로 변경했기 때문에 같이 변경했습니다.